### PR TITLE
Support for type safe JSON encoding/decoding

### DIFF
--- a/src/main/scala/lyra/App.scala
+++ b/src/main/scala/lyra/App.scala
@@ -5,6 +5,10 @@ import org.scalajs.dom
 import java.util.Optional
 import org.scalajs.dom.HTMLSelectElement
 import org.scalajs.dom.HTMLButtonElement
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+
 
 case class StylesConfig(
     color: String,
@@ -162,3 +166,6 @@ class App(canvas: dom.HTMLCanvasElement, initialData: List[Shape]) {
 
   def shapes: List[Shape] = data
 }
+
+implicit val stylesConfigDecoder: Decoder[StylesConfig] = deriveDecoder
+implicit val stylesConfigEncoder: Encoder[StylesConfig] = deriveEncoder

--- a/src/main/scala/lyra/CommandController.scala
+++ b/src/main/scala/lyra/CommandController.scala
@@ -20,7 +20,6 @@ class UndoCommandController extends CommandController {
     }
   }
   override def log(c: ShapeCommand): Unit = {
-    println(c.asJson.noSpaces)
     changes = changes ++ List(c)
     // add to undo stack only if it is not undo command, else we endup in loop
     // where only last shape will be undoed

--- a/src/main/scala/lyra/CommandController.scala
+++ b/src/main/scala/lyra/CommandController.scala
@@ -1,7 +1,7 @@
 package lyra
 import org.scalajs.dom
-
 import scala.collection.mutable
+import io.circe.syntax._
 
 trait CommandController:
   def log(c: ShapeCommand): Unit
@@ -20,6 +20,7 @@ class UndoCommandController extends CommandController {
     }
   }
   override def log(c: ShapeCommand): Unit = {
+    println(c.asJson.noSpaces)
     changes = changes ++ List(c)
     // add to undo stack only if it is not undo command, else we endup in loop
     // where only last shape will be undoed

--- a/src/main/scala/lyra/Commands.scala
+++ b/src/main/scala/lyra/Commands.scala
@@ -6,7 +6,7 @@ import io.circe.generic.semiauto._
 
 type DataSetter = (List[Shape] => List[Shape]) => Unit
 
-trait ShapeCommand:
+sealed trait ShapeCommand:
   def undo(setData: DataSetter): Unit
   def run(setData: DataSetter): Unit
 
@@ -69,3 +69,9 @@ case class RedoCommand(command: ShapeCommand) extends ShapeCommand {
 
 implicit val createShapeCommandDecoder: Decoder[CreateShapeCommand] = deriveDecoder[CreateShapeCommand]
 implicit val createShapeCommandEncoder: Encoder[CreateShapeCommand] = deriveEncoder[CreateShapeCommand]
+implicit val shapeCommandDecoder: Decoder[ShapeCommand] = deriveDecoder
+implicit val shapeCommandEncoder: Encoder[ShapeCommand] = deriveEncoder
+implicit val undoCommandDecoder: Decoder[UndoCommand] = deriveDecoder
+implicit val undoCommandEncoder: Encoder[UndoCommand] = deriveEncoder
+implicit val redoCommandDecoder: Decoder[RedoCommand] = deriveDecoder
+implicit val redoCommandEncoder: Encoder[RedoCommand] = deriveEncoder

--- a/src/main/scala/lyra/Commands.scala
+++ b/src/main/scala/lyra/Commands.scala
@@ -1,5 +1,9 @@
 package lyra
 
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+
 type DataSetter = (List[Shape] => List[Shape]) => Unit
 
 trait ShapeCommand:
@@ -62,3 +66,6 @@ case class RedoCommand(command: ShapeCommand) extends ShapeCommand {
     command.run(setData)
   }
 }
+
+implicit val createShapeCommandDecoder: Decoder[CreateShapeCommand] = deriveDecoder[CreateShapeCommand]
+implicit val createShapeCommandEncoder: Encoder[CreateShapeCommand] = deriveEncoder[CreateShapeCommand]

--- a/src/main/scala/lyra/Draw.scala
+++ b/src/main/scala/lyra/Draw.scala
@@ -71,7 +71,7 @@ trait StaticShape:
     gfx
   }
 
-trait Shape extends StaticShape:
+sealed trait Shape extends StaticShape:
   val id: String
   val user: String
   def overlap(r: Rectangle): Boolean
@@ -109,7 +109,7 @@ case class SelectionRectShape(id: String, user: String, val rect: Rectangle, sty
   }
 }
 
-trait ModifiableShape extends Shape {
+sealed trait ModifiableShape extends Shape {
   def modify(p: Point): ModifiableShape
 }
 

--- a/src/main/scala/lyra/Draw.scala
+++ b/src/main/scala/lyra/Draw.scala
@@ -1,5 +1,9 @@
 package lyra
 
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
+
 import org.scalajs.dom
 import scala.scalajs.js
 
@@ -111,8 +115,8 @@ trait ModifiableShape extends Shape {
 
 case class StrokeShape(
     id: String, user: String,
-    private val contents: List[Point],
-    val styles: StylesConfig
+    contents: List[Point],
+    styles: StylesConfig
 ) extends ModifiableShape {
 
   override def patchStyles(newStyles: StylesConfig): StaticShape =
@@ -186,3 +190,26 @@ case class EndpointsHighlight(id: String, user: String, contents: List[Point], s
 
   override def highlights: List[Point] = highlights
 }
+
+  implicit val pointDecoder: Decoder[Point] = deriveDecoder
+  implicit val pointEncoder: Encoder[Point] = deriveEncoder
+
+  implicit val rectangleDecoder: Decoder[Rectangle] = deriveDecoder
+  implicit val rectangleEncoder: Encoder[Rectangle] = deriveEncoder
+
+  implicit val deltaDecoder: Decoder[Delta] = deriveDecoder
+  implicit val deltaEncoder: Encoder[Delta] = deriveEncoder
+
+  implicit val selectionRectShapeDecoder: Decoder[SelectionRectShape] = deriveDecoder
+  implicit val selectionRectShapeEncoder: Encoder[SelectionRectShape] = deriveEncoder
+
+  implicit val strokeShapeDecoder: Decoder[StrokeShape] = deriveDecoder
+  implicit val strokeShapeEncoder: Encoder[StrokeShape] = deriveEncoder
+
+  implicit val endpointsHighlightDecoder: Decoder[EndpointsHighlight] = deriveDecoder
+  implicit val endpointsHighlightEncoder: Encoder[EndpointsHighlight] = deriveEncoder
+
+  implicit val shapeDecoder: Decoder[Shape] = deriveDecoder
+  implicit val shapeEncoder: Encoder[Shape] = deriveEncoder
+  implicit val mshapeDecoder: Decoder[ModifiableShape] = deriveDecoder
+  implicit val mshapeEncoder: Encoder[ModifiableShape] = deriveEncoder


### PR DESCRIPTION
Using circe, it is now possible to safely serialize and deserialize the important case classes
this includes
shapes, commands